### PR TITLE
Remove .html extension in URLS

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -51,7 +51,7 @@
         </div>
 
       <div class="container">
-         <a href="index.html"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
+         <a href="/innovation-fellows"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
 
         <div class="navbar-header">
 

--- a/apply.html
+++ b/apply.html
@@ -52,9 +52,9 @@
 
       <div class="container">
          <a href="index.html"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
-         
+
         <div class="navbar-header">
-          
+
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
             <span class="sr-only">Toggle navigation</span>
             <span class="icon-bar"></span>
@@ -64,23 +64,23 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a class="first" href="index.html">Overview</a></li>
-<!--             <li><a href="positions.html">Positions</a></li>            
+            <li><a class="first" href="/">Overview</a></li>
+<!--             <li><a href="positions.html">Positions</a></li>
  <li><a href="culture.html">Culture</a></li>
             <li><a href="faq.html">FAQ</a></li> -->
-            <li class="active"><a href="apply.html">Apply</a></li>
+            <li class="active"><a href="apply">Apply</a></li>
 
-            <li><a href="questions.html">FAQ</a></li>
-            <li><a href="meetup.html">Meetup with us</a></li>
+            <li><a href="questions">FAQ</a></li>
+            <li><a href="meetup">Meetup with us</a></li>
 
-            <li><a href="contact.html">Receive updates</a></li>
+            <li><a href="contact">Receive updates</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
     </nav>
 
 <hr/>
-  
+
 
 
 
@@ -89,7 +89,7 @@
             <br/>
             <h3>Join our first round of Design, Technology, &amp; Innovation Fellows</h3>
 <!--             <p>Accepting applications starting on June 1st</p>
- -->        
+ -->
       </div>
     </div><!-- /.container -->
 
@@ -99,7 +99,7 @@
             <h4 id="role">The role</h4>
             <p>As a fellow, you’ll serve as a senior practitioner on multidisciplinary project teams with career civil servants, actively demonstrating the value of iterative development and user-centered design. Our teams will work to improve a wide range of city services, which may include permitting, transportation, public works, aviation, and public safety.<p>
             <p>You’ll also serve as an expert and educator in your discipline, establishing best practices for the city and providing guidance training for other fellows and city staff.</p>
-            
+
             <h4 id="qualifications">Qualifications</h4>
             <p>The position includes the following preferred qualifications:</p>
             <ul>
@@ -121,19 +121,19 @@
             <li>Knowledge of lean and/or agile design and development methodologies, including expertise in determining when and how to use specific approaches, deliverables, and facilitation methods</li>
             <li>Demonstrated ability to share knowledge through establishing standards, mentoring team members, leading training sessions, and writing for the public</li>
             </ul>
-            
+
             <h4 id="salary-benefits">Salary and benefits</h4>
             <p>Between $32.47 and $38.46 an hour, commensurate with experience. Fellows will serve a one-year term working up to 40 hours each week.</p>
             <p>Fellows hired in 2016 will serve in temporary positions, which means that they will not be eligible for paid time off or health insurance. Fellows who work beyond one year would become eligible for health insurance through the city.</p>
-            <p>Once hired, all Fellow temporary employees are considered at will employees. Because they are temporary positions, they are not covered by the Municipal Civil Service rules of the City of Austin. </p> 
+            <p>Once hired, all Fellow temporary employees are considered at will employees. Because they are temporary positions, they are not covered by the Municipal Civil Service rules of the City of Austin. </p>
 
-            
+
             <h4 id="timeline">Timeline</h4>
             <p>Our first round of Fellows will start on September 6th for a 1-year, extendable term. We will begin offering positions on a rolling basis, so apply soon!
-</p>                       
+</p>
 
             <h4 id="application-requirements">Application requirements</h4>
-            <p>In your application, we'll ask you to identify your primary discipline areas from the list above and submit 2-3 work samples that exhibit your abilities in those areas. We also have two short essay questions (up to 250 words each):</p> 
+            <p>In your application, we'll ask you to identify your primary discipline areas from the list above and submit 2-3 work samples that exhibit your abilities in those areas. We also have two short essay questions (up to 250 words each):</p>
             <ol class="details">
               <li>Why do you want to work as a Design, Technology, and Innovation Fellow for the City of Austin?</li>
               <li>Tell us about a time when you used design and/or technology to help improve a system, service, or organization</li>
@@ -146,7 +146,7 @@
             <p><strong>Empathy and emotional intelligence:</strong> Experience in client-facing roles, navigating processes and bureaucracy, and delivering services with a strong user-facing or consumer-oriented element</p>
             <p><strong>Experience and skill at working in teams:</strong> We’re looking for people who can collaborate with folks from other disciplines on a daily basis, appreciating differences in perspective while also providing deep expertise in their area of specialization. We’re a large organization, so we want to see evidence that you can thrive in a large organization</p>
 
-            
+
             <h4 id="how-to-apply">How to apply</h4>
             <p>You must apply at the City of Austin jobs website. We'll post the link to the posting as soon as it's live (which should be very close to June 1st).</p>
 
@@ -159,21 +159,21 @@
 
 
 
-            
+
       </div>
 
     </div><!-- /.container -->
 
 
 
-         
+
 
     </div><!-- /.container -->
 
 
-   
 
-          
+
+
 
  </br></br></br>
 
@@ -192,15 +192,15 @@
 
 
       <div class="col-md-4 footertext">
-      <p>Forked with gratitude from <a href="http://www.nyc.gov/html/techjobs/html/index.html">NYC Tech Jobs</a></p>  
+      <p>Forked with gratitude from <a href="http://www.nyc.gov/html/techjobs/html/index.html">NYC Tech Jobs</a></p>
       <p><a href="https://github.com/cityofaustin/innovation-fellows/blob/master/contact.html">Edit this page on GitHub</a></p>
- 
+
 <!--        <div class="col-md-3">
       <a href="">Website</a></br>
       <a href="">Website</a></br>
       <a href="">Website</a></br></br>
       </div> -->
-      
+
     <!--         <p><a target="_blank" href="http://www1.nyc.gov/home/privacy-policy.page" title="Privicy">Privacy Policy</a>.
             <a target="_blank" href="http://www1.nyc.gov/home/terms-of-use.page" title="TOU">Terms of Use</a>.</p> -->
       </div>
@@ -226,7 +226,7 @@
   ga('send', 'pageview');
 
 </script>
-    
+
 <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[1]='NAME';ftypes[1]='text';fnames[0]='EMAIL';ftypes[0]='email';fnames[3]='FELLOWURL';ftypes[3]='url';fnames[4]='ADDTLNOTES';ftypes[4]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
 
 

--- a/apply.html
+++ b/apply.html
@@ -64,7 +64,7 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a class="first" href="/">Overview</a></li>
+            <li><a class="first" href="/innovation-fellows">Overview</a></li>
 <!--             <li><a href="positions.html">Positions</a></li>
  <li><a href="culture.html">Culture</a></li>
             <li><a href="faq.html">FAQ</a></li> -->

--- a/contact.html
+++ b/contact.html
@@ -51,7 +51,7 @@
         </div>
 
       <div class="container">
-         <a href="index.html"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
+         <a href=/innovation-fellows><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
 
         <div class="navbar-header">
 

--- a/contact.html
+++ b/contact.html
@@ -52,9 +52,9 @@
 
       <div class="container">
          <a href="index.html"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
-         
+
         <div class="navbar-header">
-          
+
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
             <span class="sr-only">Toggle navigation</span>
             <span class="icon-bar"></span>
@@ -64,25 +64,25 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a class="first" href="index.html">Overview</a></li>
-<!--             <li><a href="positions.html">Positions</a></li>            
+            <li><a class="first" href="/">Overview</a></li>
+<!--             <li><a href="positions.html">Positions</a></li>
  <li><a href="culture.html">Culture</a></li>
             <li><a href="faq.html">FAQ</a></li> -->
 
-            <li><a href="apply.html">Apply</a></li>
+            <li><a href="apply">Apply</a></li>
 
-            <li><a href="questions.html">FAQ</a></li>
-            <li><a href="meetup.html">Meetup with us</a></li>
-            
+            <li><a href="questions">FAQ</a></li>
+            <li><a href="meetup">Meetup with us</a></li>
 
-            <li class="active"><a href="contact.html">Receive updates</a></li>
+
+            <li class="active"><a href="contact">Receive updates</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
     </nav>
 
 <hr/>
-  
+
 
 
 
@@ -90,17 +90,17 @@
       <div class="col-md-10">
             <br/>
             <h3>Interested in joining us?<br/>We would love to hear from you.</h3>
-        
+
       </div>
     </div><!-- /.container -->
 
 
     <div class="container" >
       <div class="col-md-9">
-            <p>Send us an email at <a href="mailto:innovationfellows@austintexas.gov">innovationfellows@austintexas.gov</a> or sign up for updates using the form below.</p> 
+            <p>Send us an email at <a href="mailto:innovationfellows@austintexas.gov">innovationfellows@austintexas.gov</a> or sign up for updates using the form below.</p>
             <br/>
 
-            
+
       </div>
 
     </div><!-- /.container -->
@@ -109,7 +109,7 @@
 </br>
 
    <div class="container dti-contact-form" >
-              
+
 <h4>Receive updates</h4>
   <p class="sign-up-terms">Use this form to tell us about yourself and receive emails about the program.</p>
 
@@ -205,14 +205,14 @@
 
             </div> <!-- container -->
 
-         
+
 
     </div><!-- /.container -->
 
 
-   
 
-          
+
+
 
  </br></br></br>
 
@@ -231,15 +231,15 @@
 
 
       <div class="col-md-4 footertext">
-      <p>Forked with gratitude from <a href="http://www.nyc.gov/html/techjobs/html/index.html">NYC Tech Jobs</a></p>  
+      <p>Forked with gratitude from <a href="http://www.nyc.gov/html/techjobs/html/index.html">NYC Tech Jobs</a></p>
       <p><a href="https://github.com/cityofaustin/innovation-fellows/blob/master/contact.html">Edit this page on GitHub</a></p>
- 
+
 <!--        <div class="col-md-3">
       <a href="">Website</a></br>
       <a href="">Website</a></br>
       <a href="">Website</a></br></br>
       </div> -->
-      
+
     <!--         <p><a target="_blank" href="http://www1.nyc.gov/home/privacy-policy.page" title="Privicy">Privacy Policy</a>.
             <a target="_blank" href="http://www1.nyc.gov/home/terms-of-use.page" title="TOU">Terms of Use</a>.</p> -->
       </div>
@@ -265,7 +265,7 @@
   ga('send', 'pageview');
 
 </script>
-    
+
 <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[1]='NAME';ftypes[1]='text';fnames[0]='EMAIL';ftypes[0]='email';fnames[3]='FELLOWURL';ftypes[3]='url';fnames[4]='ADDTLNOTES';ftypes[4]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
 
 

--- a/contact.html
+++ b/contact.html
@@ -64,7 +64,7 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a class="first" href="/">Overview</a></li>
+            <li><a class="first" href="/innovation-fellows">Overview</a></li>
 <!--             <li><a href="positions.html">Positions</a></li>
  <li><a href="culture.html">Culture</a></li>
             <li><a href="faq.html">FAQ</a></li> -->

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         </div>
 
       <div class="container">
-         <a href="index.html"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
+         <a href="/innovation-fellows"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
 
         <div class="navbar-header">
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
- 
+
     <title>City of Austin Design, Technology, and Innovation Fellows</title>
 
     <meta name="description" content="The City of Austin's Design, Technology, and Innovation Fellows program provides an opportunity for Austin’s passionate and civic-minded designers and developers to bring the principles, values, and practices of the technology sector into government.">
@@ -54,9 +54,9 @@
 
       <div class="container">
          <a href="index.html"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
-         
+
         <div class="navbar-header">
-          
+
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
             <span class="sr-only">Toggle navigation</span>
             <span class="icon-bar"></span>
@@ -67,15 +67,15 @@
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
             <li class="active"><a class="first" href="#">Overview</a></li>
-<!--             <li><a href="positions.html">Positions</a></li>            
+<!--             <li><a href="positions.html">Positions</a></li>
  <li><a href="culture.html">Culture</a></li>
             <li><a href="faq.html">FAQ</a></li> -->
-            <li><a href="apply.html">Apply</a></li>
+            <li><a href="apply">Apply</a></li>
 
-            <li><a href="questions.html">FAQ</a></li>
-            <li><a href="meetup.html">Meetup with us</a></li>
+            <li><a href="questions">FAQ</a></li>
+            <li><a href="meetup">Meetup with us</a></li>
 
-            <li><a href="contact.html">Receive updates</a></li>
+            <li><a href="contact">Receive updates</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
@@ -85,7 +85,7 @@
   <div id="home-image" class="container-fluid">
 
 
-      
+
             <!-- <p>&nbsp;</p>
             <p>&nbsp;</p>
             <p>&nbsp;</p>
@@ -96,7 +96,7 @@
 
 <!--             <p>&nbsp;</p>
             <p>&nbsp;</p> -->
-      
+
 
     </div>
 
@@ -106,9 +106,9 @@
 
     <div class="container" >
       <div class="col-md-10">
-        
+
             <p class="lead">We're looking for top talent in design, development, data analytics, user research, and product management</p>
-        
+
       </div>
     </div><!-- /.container -->
 
@@ -117,12 +117,12 @@
 
    <div class="container" >
       <div class="col-md-8">
-            <p>The City of Austin’s Design, Technology, and Innovation Fellows program provides an opportunity for Austin’s passionate and civic-minded designers and developers to bring the principles, values, and practices of the technology sector into government.</p> 
+            <p>The City of Austin’s Design, Technology, and Innovation Fellows program provides an opportunity for Austin’s passionate and civic-minded designers and developers to bring the principles, values, and practices of the technology sector into government.</p>
 
             <p>Inspired by the success of programs at the <a href="http://www.consumerfinance.gov/jobs/technology-innovation-fellows/">Consumer Financial Protection Bureau</a>, <a href="https://18f.gsa.gov/">18F</a>, <a href="https://www.codeforamerica.org/">Code for America</a>, and the <a href="https://www.whitehouse.gov/digital/united-states-digital-service">U.S. Digital Service</a>, our program is looking for experienced innovators who can join us to tackle some of the City’s biggest challenges.</p>
       </div>
 
-  <!--       
+  <!--
   <div class="col-md-8">
             <h4>The Alpha Round: Start now</h4>
             <p><i>Accepting applications in early April through May 20th</i></p>
@@ -130,13 +130,13 @@
             <p>These early Fellows will commit to a 6-month term, and will also be eligible to join the class of Fellows starting in September.</p>
             <a class="btn btn__secondary" href="contact.html">Tell us you're interested</a>
             <br/>
-    </div> 
+    </div>
     -->
 
 
       <br/>
       <div class="col-md-8">
-      
+
             <h4>The First Round: Start on September 6th</h4>
             <p><i>Accepting applications in early June</i></p>
             <p>Our first round of Fellows will serve on agile, multi-disciplinary teams assigned to focus areas throughout the city. We’re looking for experienced practitioners and project leaders in all areas of user-centered design, web development, data analytics, and product management. If you think you can help us, we'd love to hear from you.</p>
@@ -159,7 +159,7 @@
           <center>
             <p class="lead">Here's why you should join us:</p>
           </center>
-          
+
           <div class="col-sm-4">
             <center>
               <img class="img-responsive" src="img/icon1.png" style="width: 60%;">
@@ -192,10 +192,10 @@
 
 
 
-      
 
 
-          
+
+
 
  </br></br></br>
 
@@ -214,15 +214,15 @@
 
 
       <div class="col-md-4 footertext">
-      <p>Forked with gratitude from <a href="http://www.nyc.gov/html/techjobs/html/index.html">NYC Tech Jobs</a></p>  
+      <p>Forked with gratitude from <a href="http://www.nyc.gov/html/techjobs/html/index.html">NYC Tech Jobs</a></p>
       <p><a href="https://github.com/cityofaustin/innovation-fellows/blob/master/index.html">Edit this page on GitHub</a></p>
- 
+
 <!--        <div class="col-md-3">
       <a href="">Website</a></br>
       <a href="">Website</a></br>
       <a href="">Website</a></br></br>
       </div> -->
-      
+
     <!--         <p><a target="_blank" href="http://www1.nyc.gov/home/privacy-policy.page" title="Privicy">Privacy Policy</a>.
             <a target="_blank" href="http://www1.nyc.gov/home/terms-of-use.page" title="TOU">Terms of Use</a>.</p> -->
       </div>
@@ -236,7 +236,7 @@
     <script src="js/bootstrap.min.js"></script>
     <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
     <script src="js/ie10-viewport-bug-workaround.js"></script>
-  
+
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -247,5 +247,5 @@
   ga('send', 'pageview');
 
 </script>
-    
+
   </body>

--- a/meetup.html
+++ b/meetup.html
@@ -51,7 +51,7 @@
         </div>
 
       <div class="container">
-         <a href="index.html"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
+         <a href="/innovation-fellows"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
 
         <div class="navbar-header">
 

--- a/meetup.html
+++ b/meetup.html
@@ -52,9 +52,9 @@
 
       <div class="container">
          <a href="index.html"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
-         
+
         <div class="navbar-header">
-          
+
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
             <span class="sr-only">Toggle navigation</span>
             <span class="icon-bar"></span>
@@ -64,24 +64,24 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a class="first" href="index.html">Overview</a></li>
-<!--             <li><a href="positions.html">Positions</a></li>            
+            <li><a class="first" href="/">Overview</a></li>
+<!--             <li><a href="positions.html">Positions</a></li>
  <li><a href="culture.html">Culture</a></li>
             <li><a href="faq.html">FAQ</a></li> -->
-            <li><a href="apply.html">Apply</a></li>
+            <li><a href="apply">Apply</a></li>
 
-            <li><a href="questions.html">FAQ</a></li>
+            <li><a href="questions">FAQ</a></li>
 
-            <li class="active"><a href="meetup.html">Meetup with us</a></li>
+            <li class="active"><a href="meetup">Meetup with us</a></li>
 
-            <li><a href="contact.html">Receive updates</a></li>
+            <li><a href="contact">Receive updates</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
     </nav>
 
 <hr/>
-  
+
 
 
 
@@ -89,9 +89,9 @@
       <div class="col-md-10">
             <br/>
             <h3>Meetup with us</h3>
-            <p>We'll be attending these events while we recruit over the summer. 
+            <p>We'll be attending these events while we recruit over the summer.
             <br/>Send us an email at <a href="mailto:innovationfellows@austintexas.gov">innovationfellows@austintexas.gov</a> if you're planning to attend so we can make sure to speak with you!</p>
-        
+
       </div>
     </div><!-- /.container -->
 
@@ -118,24 +118,24 @@
             <h4 class="event-name">Action Design ATX</h4>
             <p>Monday, June 27, 6:30pm to 9:00pm<br/>
             <i>Capital Factory, 701 Brazos Street</i></br/>
-            <a href="http://www.meetup.com/action_design_ATX/events/230662559/">http://www.meetup.com</a>  </p>           
+            <a href="http://www.meetup.com/action_design_ATX/events/230662559/">http://www.meetup.com</a>  </p>
 
 
-            
+
       </div>
 
     </div><!-- /.container -->
 
 
 
-         
+
 
     </div><!-- /.container -->
 
 
-   
 
-          
+
+
 
  </br></br></br>
 
@@ -154,15 +154,15 @@
 
 
       <div class="col-md-4 footertext">
-      <p>Forked with gratitude from <a href="http://www.nyc.gov/html/techjobs/html/index.html">NYC Tech Jobs</a></p>  
+      <p>Forked with gratitude from <a href="http://www.nyc.gov/html/techjobs/html/index.html">NYC Tech Jobs</a></p>
       <p><a href="https://github.com/cityofaustin/innovation-fellows/blob/master/contact.html">Edit this page on GitHub</a></p>
- 
+
 <!--        <div class="col-md-3">
       <a href="">Website</a></br>
       <a href="">Website</a></br>
       <a href="">Website</a></br></br>
       </div> -->
-      
+
     <!--         <p><a target="_blank" href="http://www1.nyc.gov/home/privacy-policy.page" title="Privicy">Privacy Policy</a>.
             <a target="_blank" href="http://www1.nyc.gov/home/terms-of-use.page" title="TOU">Terms of Use</a>.</p> -->
       </div>
@@ -188,7 +188,7 @@
   ga('send', 'pageview');
 
 </script>
-    
+
 <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[1]='NAME';ftypes[1]='text';fnames[0]='EMAIL';ftypes[0]='email';fnames[3]='FELLOWURL';ftypes[3]='url';fnames[4]='ADDTLNOTES';ftypes[4]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
 
 

--- a/meetup.html
+++ b/meetup.html
@@ -64,7 +64,7 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a class="first" href="/">Overview</a></li>
+            <li><a class="first" href="/innovation-fellows">Overview</a></li>
 <!--             <li><a href="positions.html">Positions</a></li>
  <li><a href="culture.html">Culture</a></li>
             <li><a href="faq.html">FAQ</a></li> -->

--- a/questions.html
+++ b/questions.html
@@ -51,7 +51,7 @@
         </div>
 
       <div class="container">
-         <a href="index.html"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
+         <a href="/innovation-fellows"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
 
         <div class="navbar-header">
 

--- a/questions.html
+++ b/questions.html
@@ -52,9 +52,9 @@
 
       <div class="container">
          <a href="index.html"><img class="img-responsive" src="img/fellows-logo-wide.png" alt="Logo for City of Austin Design, Technology, and Innovation Fellows"></a>
-         
+
         <div class="navbar-header">
-          
+
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
             <span class="sr-only">Toggle navigation</span>
             <span class="icon-bar"></span>
@@ -64,24 +64,24 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a class="first" href="index.html">Overview</a></li>
-<!--             <li><a href="positions.html">Positions</a></li>            
+            <li><a class="first" href="/">Overview</a></li>
+<!--             <li><a href="positions.html">Positions</a></li>
  <li><a href="culture.html">Culture</a></li>
             <li><a href="faq.html">FAQ</a></li> -->
 
-            <li><a href="apply.html">Apply</a></li>
+            <li><a href="apply">Apply</a></li>
 
-            <li class="active"><a href="questions.html">FAQ</a></li>
-            <li><a href="meetup.html">Meetup with us</a></li>
+            <li class="active"><a href="questions">FAQ</a></li>
+            <li><a href="meetup">Meetup with us</a></li>
 
-            <li><a href="contact.html">Receive updates</a></li>
+            <li><a href="contact">Receive updates</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
     </nav>
 
 <hr/>
-  
+
 
 
 
@@ -89,7 +89,7 @@
       <div class="col-md-10">
             <br/>
             <h3>Frequently asked questions</h3>
-        
+
       </div>
     </div><!-- /.container -->
 
@@ -98,7 +98,7 @@
       <div class="col-md-9">
             <p>We've included answers to questions that we've been asked about the program so far. If you have additional questions, send us an email at <a href="mailto:innovationfellows@austintexas.gov">innovationfellows@austintexas.gov</a> and we'll get back to you as soon as we can.</p>
             <br/>
-            <p>> <a href="#why">I have a lot of options in the tech sector. Why should I become a fellow?</a></p> 
+            <p>> <a href="#why">I have a lot of options in the tech sector. Why should I become a fellow?</a></p>
             <p>> <a href="#work">What kind of work will Fellows do?</a></p>
             <p>> <a href="#people">What kinds of people are you looking for?</a></p>
             <p>> <a href="#application-process">How does the application process work?</a></p>
@@ -108,14 +108,14 @@
             <p>> <a href="#location">Where will the work be located?</a></p>
             <p>> <a href="#typical-day">What will a typical day look like?</a></p>
             <p>&nbsp;</p>
-            
+
             <h4 id="why" class="faq-heading">I have a lot of options in the tech sector. Why should I become a fellow?</h4>
             <p class="faq-answer">This is an opportunity for you to have a huge impact. Our city is responsible for providing necessary services to over a million people every day, and we need your expertise to help improve those services.</p>
             <p>You’ll also join a growing community of civic leaders who are working to create a more open, accountable, and participatory government, and you’ll help us establish new standards and practices that we can share with other cities. For examples of these practices in action, check out the work from <a href="https://18f.gsa.gov/">18F</a>, the <a href="https://www.usds.gov/">US Digital Service</a>, and the <a href="https://gds.blog.gov.uk/">UK Government Digital Service</a>.</p>
-            
+
             <h4 id="work" class="faq-heading">What kind of work will Fellows do?</h4>
             <p class="faq-answer">Fellows will serve on multidisciplinary project teams of designers, developers, researchers, and subject-matter experts working to to improve city services through iterative, user-centered design and development. The breadth of city services spans across all city functions, including public safety, permitting, resource recovery, and event management, and project work can range from early research and prototyping to detailed design and implementation. We’ll look to each fellow’s strengths and interests in order to match them with projects where they can have the greatest impact.</p>
-            
+
             <h4 id="people" class="faq-heading">What kinds of people are you looking for?</h4>
             <p class="faq-answer">We’re looking for practitioners and project leaders in all areas of design, technology, and innovation with at least three years of experience working on multidisciplinary teams and producing great work. We need people who can challenge the status quo while appreciating the work that’s already being done, which requires a balance of assertiveness, patience, and humility.</p>
             <p>As we review applications, we'll consider the following areas:</p>
@@ -123,7 +123,7 @@
             <p><strong>Tools and execution</strong>: Experience in iterative design, development, and deployment of solutions using current and emergent technologies and best practices</p>
             <p><strong>Empathy and emotional intelligence</strong>: Experience in client-facing roles, navigating processes and bureaucracy, and delivering services with a strong user-facing or consumer-oriented element</p>
             <p><strong>Experience and skill at working in teams</strong>: We’re looking for people who can collaborate with folks from other disciplines on a daily basis, appreciating differences in perspective while also providing deep expertise in their area of specialization. We’re a large organization, so we want to see evidence that you can thrive in a large organization</p>
-            
+
             <h4 id="application-process" class="faq-heading">How does the application process work?</h4>
             <p class="faq-answer">We’ll start reviewing applications in mid-June on a rolling basis. Based on the resume, essays, and work samples in each application, we’ll select top candidates for interviews. The interview process will include a combination of remote sessions over Google Hangouts and in-person sessions at City Hall.</p>
 
@@ -155,21 +155,21 @@
 
 
 
-            
+
       </div>
 
     </div><!-- /.container -->
 
 
 
-         
+
 
     </div><!-- /.container -->
 
 
-   
 
-          
+
+
 
  </br></br></br>
 
@@ -188,15 +188,15 @@
 
 
       <div class="col-md-4 footertext">
-      <p>Forked with gratitude from <a href="http://www.nyc.gov/html/techjobs/html/index.html">NYC Tech Jobs</a></p>  
+      <p>Forked with gratitude from <a href="http://www.nyc.gov/html/techjobs/html/index.html">NYC Tech Jobs</a></p>
       <p><a href="https://github.com/cityofaustin/innovation-fellows/blob/master/contact.html">Edit this page on GitHub</a></p>
- 
+
 <!--        <div class="col-md-3">
       <a href="">Website</a></br>
       <a href="">Website</a></br>
       <a href="">Website</a></br></br>
       </div> -->
-      
+
     <!--         <p><a target="_blank" href="http://www1.nyc.gov/home/privacy-policy.page" title="Privicy">Privacy Policy</a>.
             <a target="_blank" href="http://www1.nyc.gov/home/terms-of-use.page" title="TOU">Terms of Use</a>.</p> -->
       </div>
@@ -222,7 +222,7 @@
   ga('send', 'pageview');
 
 </script>
-    
+
 <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[1]='NAME';ftypes[1]='text';fnames[0]='EMAIL';ftypes[0]='email';fnames[3]='FELLOWURL';ftypes[3]='url';fnames[4]='ADDTLNOTES';ftypes[4]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
 
 

--- a/questions.html
+++ b/questions.html
@@ -64,7 +64,7 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a class="first" href="/">Overview</a></li>
+            <li><a class="first" href="/innovation-fellows">Overview</a></li>
 <!--             <li><a href="positions.html">Positions</a></li>
  <li><a href="culture.html">Culture</a></li>
             <li><a href="faq.html">FAQ</a></li> -->


### PR DESCRIPTION
Because this site is hosted with GitHub pages the `.html` extensions at the end of the URL are redundant. This removes them making the URLS:

- https://cityofaustin.github.io/innovation-fellows/
- https://cityofaustin.github.io/innovation-fellows/apply
- etc

You can test this on my fork: https://ascott1.github.io/innovation-fellows/

Note: Because of the way Jekyll handles these urls https://cityofaustin.github.io/innovation-fellows/apply will work but adding a trailing slash `/` (https://cityofaustin.github.io/innovation-fellows/apply/) will return a 404. If you'd rather keep the explicit 404, feel free to close this PR.